### PR TITLE
Better handling of shape mismatches

### DIFF
--- a/approx/runtime/src/approx_surrogate.h
+++ b/approx/runtime/src/approx_surrogate.h
@@ -109,6 +109,16 @@ typedef struct internal_tensor_repr_data {
       auto &opt = Tensors[0];
       if (opt.sizes() == T.sizes()) {
         opt.copy_(T);
+      } else {
+        T = T.squeeze(0);
+        if(opt.sizes() == T.sizes()) {
+          opt.copy_(T);
+          return;
+        }
+        std::cout << "Error: The output tensor does not match the expected shape\n"
+                  << "Expected: " << opt.sizes() << " Got: " << T.sizes() << "\n"
+                  << "Skipping update\n"
+                  << "Please check the model architecture\n";
       }
       return;
     }


### PR DESCRIPTION
Sometimes, the model outputs something of shape [1, S], and the output tensor has shape [S].
This PR handles that case by trying to squeeze model output tensors if the model output's shape doesn't match the wrapped output memory. If squeezing doesn't work, report the issue to the user.